### PR TITLE
Fix: AAC segments incorrectly identified as TS

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/ExoPlayerLibraryInfo.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/ExoPlayerLibraryInfo.java
@@ -30,11 +30,11 @@ public final class ExoPlayerLibraryInfo {
 
   /** The version of the library expressed as a string, for example "1.2.3". */
   // Intentionally hardcoded. Do not derive from other constants (e.g. VERSION_INT) or vice versa.
-  public static final String VERSION = "2.12.4";
+  public static final String VERSION = "2.12.5";
 
   /** The version of the library expressed as {@code "ExoPlayerLib/" + VERSION}. */
   // Intentionally hardcoded. Do not derive from other constants (e.g. VERSION) or vice versa.
-  public static final String VERSION_SLASHY = "ExoPlayerLib/2.12.4";
+  public static final String VERSION_SLASHY = "ExoPlayerLib/2.12.5";
 
   /**
    * The version of the library expressed as an integer, for example 1002003.
@@ -44,7 +44,7 @@ public final class ExoPlayerLibraryInfo {
    * integer version 123045006 (123-045-006).
    */
   // Intentionally hardcoded. Do not derive from other constants (e.g. VERSION) or vice versa.
-  public static final int VERSION_INT = 2012004;
+  public static final int VERSION_INT = 2012005;
 
   /** The default user agent for requests made by the library. */
   public static final String DEFAULT_USER_AGENT =

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/DefaultHlsExtractorFactory.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/DefaultHlsExtractorFactory.java
@@ -121,6 +121,10 @@ public final class DefaultHlsExtractorFactory implements HlsExtractorFactory {
       Extractor extractor =
           checkNotNull(
               createExtractorByFileType(fileType, format, muxedCaptionFormats, timestampAdjuster));
+      // Force ADTS extractor for files with .aac extension (Remove once Google patches ExoPlayer)
+      if (fileType == FileTypes.ADTS && uriInferredFileType == FileTypes.ADTS) {
+        return new BundledHlsMediaChunkExtractor(extractor, format, timestampAdjuster);
+      }
       if (sniffQuietly(extractor, extractorInput)) {
         return new BundledHlsMediaChunkExtractor(extractor, format, timestampAdjuster);
       }


### PR DESCRIPTION
* Force ADTS extractor for files with `.aac` extension